### PR TITLE
Create a GitHub action that publishes template on NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:
@@ -14,12 +14,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          registry-url: https://registry.npmjs.org
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: yarn
 
       - name: Publish to NPM
-        run: yarn npm publish --access public
+        run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to NPM
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Publish to NPM
+        run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,6 @@ jobs:
         run: yarn
 
       - name: Publish to NPM
-        run: yarn npm publish
+        run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish to NPM
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build:
@@ -20,6 +20,6 @@ jobs:
         run: yarn
 
       - name: Publish to NPM
-        run: yarn npm publish
+        run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,5 @@
     "@types/react-native": "~0.69.1",
     "babel-plugin-module-resolver": "^4.1.0",
     "typescript": "^4.9.4"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
Hi, I am Nguyen Tien Manh, ID 2013736, a member of  'Nhom D' Team and a student of  CO3043 (L02) class.

This pull request creates a GitHub action that automatically publishes package on NPM after publishing a release.

Changes Made:
- Create publish.yml file.
- Remove "private: true" line in package.json file which prevents GitHub action from publishing the template.

Testing:
- Created a secret named **_NPM_TOKEN_**.
- Manually created a release with 1.1.0 tag and waited for action to complete.

Result:
- Package was successfully published: [https://www.npmjs.com/package/expo-redux-template](https://www.npmjs.com/package/expo-redux-template)

Please review this pull request and let me know if any further modifications are needed. Contact me via:
- Telegram: 0943511677
- Email: ntmanh.dev@outlook.com

Thank you.